### PR TITLE
Fixes for Campaign Member Creation and Lead Mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.iml
+.idea/
+IlluminatedCloud

--- a/src/classes/INT_InteractionMappingService.cls
+++ b/src/classes/INT_InteractionMappingService.cls
@@ -5,11 +5,12 @@
 ******************************************/
 public class INT_InteractionMappingService {
     private Map<String, Set<String>> skipMappingMap = new Map<String, Set<String>>();
-    private Map<String, List<Interaction_Mapping__c>> intMappingMap = new Map<String, List<Interaction_Mapping__c>>();
+    public Map<String, List<Interaction_Mapping__c>> intMappingMap = new Map<String, List<Interaction_Mapping__c>>();
 
     public INT_InteractionMappingService() {
         for (Interaction_Mapping__c mapping : [
-            SELECT Skip_Mapping__c, Insert_Null__c, Target_Object_API_Name__c, Interaction_Source_Field_API_Name__c, Target_Field_API_Name__c
+            SELECT Skip_Mapping__c, Insert_Null__c, Target_Object_API_Name__c, Source_Field_API_Name__c,
+                Target_Field_API_Name__c, Source_Object_API_Name__c
             FROM Interaction_Mapping__c
             WHERE Active__c = true
         ]) {
@@ -27,10 +28,10 @@ public class INT_InteractionMappingService {
     }
 
     /**
-     * @description Checks to see if field has an excluded source 
+     * @description Checks to see if field has an excluded source
      * @param mappingId, the Interaction_Mapping__c record Id to pull the record from the Map.
      * @param interactionSource, the value of the Interaction.Interaction_Source__c field.
-     * @param skipOrPreserveSourcesMap, the Map containing the Skip Mapping 
+     * @param skipOrPreserveSourcesMap, the Map containing the Skip Mapping
      * @return a Boolean determining whether or not the field is excluded or overwrite if blank.
      */
     private Boolean isSkipOrPreserveSourceField(
@@ -57,15 +58,33 @@ public class INT_InteractionMappingService {
                 if (isSkipOrPreserveSourceField(mapping.Id, interaction.Interaction_Source__c, skipMappingMap)) {
                     continue; // Prevent mapping of field if it's a skip field or a preserve target source
                 } else if (mapping.Insert_Null__c
-                    || (interaction.get(mapping.Interaction_Source_Field_API_Name__c) != null
-                        && interaction.get(mapping.Interaction_Source_Field_API_Name__c) != '')
+                    || (interaction.get(mapping.Source_Field_API_Name__c) != null
+                        && interaction.get(mapping.Source_Field_API_Name__c) != '')
                 ) {
-                    theObject.put(mapping.Target_Field_API_Name__c, interaction.get(mapping.Interaction_Source_Field_API_Name__c));
+                    theObject.put(mapping.Target_Field_API_Name__c, interaction.get(mapping.Source_Field_API_Name__c));
                 }
 
             }
         }
 
         return theObject;
+    }
+
+    /**
+     * @description Applies data from a source Object to the Interaction__c based upon Interaction_Mapping__c records.
+     * @param theObject, the SObject to pull data from.
+     * @param interaction, the Interaction__c record to populate.
+     * @return interaction, the populated Interaction__c record.
+     */
+    public Interaction__c applyDataToInteraction(SObject theObject, Interaction__c interaction) {
+        if (intMappingMap.containsKey('Interaction__c')) {
+            for (Interaction_Mapping__c mapping : intMappingMap.get('Interaction__c')) {
+                if (mapping.Source_Object_API_Name__c == theObject.getSObjectType().getDescribe().getName()) {
+                    interaction.put(mapping.Target_Field_API_Name__c, theObject.get(mapping.Source_Field_API_Name__c));
+                }
+            }
+        }
+
+        return interaction;
     }
 }

--- a/src/classes/INT_InteractionProcessor.cls
+++ b/src/classes/INT_InteractionProcessor.cls
@@ -164,7 +164,7 @@ public class INT_InteractionProcessor {
             logPossibleErrors(Database.upsert(campaignMembersToUpsert, CampaignMember.Campaign_Member_Key__c, false));
         }
 
-        // Attempt initial converstion of leads.
+        // Attempt initial conversion of leads.
         List<Database.LeadConvert> possibleLeadsToReconvert = convertLeads(newLeads);
 
         // Reconvert Leads with matched Contacts if duplicate errors.
@@ -213,11 +213,6 @@ public class INT_InteractionProcessor {
         // Upsert Affiliations using the Upsert_Key__c
         if (affiliationsToUpsert.size() > 0) {
             logPossibleErrors(Database.upsert(affiliationsToUpsert, hed__Affiliation__c.Upsert_Key__c, false));
-        }
-
-        // Upsert CampaignMembers
-        if (campaignMembersToUpsert.size() > 0) {
-            logPossibleErrors(Database.upsert(campaignMembersToUpsert, CampaignMember.Campaign_Member_Key__c, false));
         }
 
         // Add any duplicates found and update the Interactions with new Status from processing.
@@ -297,7 +292,7 @@ public class INT_InteractionProcessor {
             intMappingService.applyDataToSObject(interaction, newLead);
         }
 
-        leadConverts.addAll(insertLeads(interactionIdToLead.values()));
+        leadConverts.addAll(insertLeads(interactionIdToLead.values(), interactions));
 
         return leadConverts;
     }
@@ -307,57 +302,52 @@ public class INT_InteractionProcessor {
      * @param leads, a List of Lead objects to insert.
      * @return leadsToConvert, a List of Database.LeadConvert records to convert.
      */
-    private List<Database.LeadConvert> insertLeads(List<Lead> leadsToInsert) {
+    private List<Database.LeadConvert> insertLeads(List<Lead> leadsToInsert, List<Interaction__c> interactions) {
+        Integer leadIndex = 0;
         Database.SaveResult[] srlist = Database.insert(leadsToInsert, false); // Insert Leads
         List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>();
-        Map<Id, Database.SaveResult> leadResultMap = new Map<Id, Database.SaveResult>();
 
-        for (Database.SaveResult sr : srlist) leadResultMap.put(sr.getId(), sr);
+        for (Database.SaveResult sr : srlist)  {
+            Interaction__c interaction = interactions[leadIndex];
 
-        for (Id intearctionId : interactionIdToLead.keySet()) {
-            if (leadResultMap.containsKey(interactionIdToLead.get(intearctionId).Id)) {
-                Database.SaveResult sr = leadResultMap.get(interactionIdToLead.get(intearctionId).Id);
-                Id leadId = interactionIdToLead.get(intearctionId).Id;
-                Interaction__c interaction = interactionMap.get(intearctionId);
+            if (sr.isSuccess()) { // Check if insert was a success
+                // On success, prepare to convert inserted lead.
+                Id leadId = sr.getId();
+                leadsToConvert.add(createLeadConvert(interactionMap.get(interaction.Id), leadId, true));
+                interaction.Lead__c = leadId; // Copy new Lead Id to the Interaction__c record.
+                if (!interaction.Lead_Only__c) leadsToDelete.add(new Lead(Id = leadId)); // Newly created leads will be deleted
+            } else {
+                /**
+                 * If there are errors, loop through them and either log the error on the Interaction.
+                 * or see if there's a duplicate and use that instead.
+                 */
+                for (Database.Error error : sr.getErrors()) {
+                    if (error.getStatusCode() == StatusCode.DUPLICATES_DETECTED) {
+                        Database.DuplicateError dupErrorError = (Database.DuplicateError) error;
 
-                if (sr.isSuccess()) { // Check if insert was a success
-                    // On success, prepare to convert inserted lead.
-                    leadIds.add(sr.getId());
-                    leadsToConvert.add(createLeadConvert(interactionMap.get(intearctionId), leadId, true));
-                    interaction.Lead__c = leadId;
-                    leadIdToInteractionMap.put(interaction.Lead__c, interaction);
+                        for (Datacloud.MatchResult matchResult : dupErrorError.getDuplicateResult().getMatchResults()) {
+                            for (Datacloud.MatchRecord match : matchResult.getMatchRecords()) {
+                                // Grab matched record to use instead of the new one.
+                                interaction.Lead__c = match.getRecord().Id;
 
-                    if (interaction.Lead_Only__c == false) {
-                        leadsToDelete.add(new Lead(Id = leadId)); // Newly created leads will be deleted
-                    }
-                } else {
-                    /**
-                     * If there are errors, loop through them and either log the error on the Interaction.
-                     * or see if there's a duplicate and use that instead.
-                     */
-                    for (Database.Error error : sr.getErrors()) {
-                        if (error.getStatusCode() == StatusCode.DUPLICATES_DETECTED) {
-                            Database.DuplicateError dupErrorError = (Database.DuplicateError) error;
-
-                            for (Datacloud.MatchResult matchResult : dupErrorError.getDuplicateResult().getMatchResults()) {
-                                for (Datacloud.MatchRecord match : matchResult.getMatchRecords()) {
-                                    // Grab matched record to use instead of the new one.
-                                    leadIds.add(match.getRecord().Id);
-                                    interaction.Lead__c = match.getRecord().Id;
-                                    leadIdToInteractionMap.put(interaction.Lead__c, interaction);
-
-                                    if (interaction.Lead_Only__c == false) {
+                                if (interaction.Lead_Only__c == true) {
+                                    leadIdToInteractionMap.put(interaction.Lead__c,interaction);
+                                } else {
+                                    // The matched Lead doesn't exist in the current transaction, so add it to List to convert.
+                                    if (leadIdToInteractionMap.get(match.getRecord().Id) == null) {
                                         leadsToConvert.add(createLeadConvert(interaction, match.getRecord().Id, true));
                                     }
                                 }
                             }
-                        } else { // Catch-all for all other errors
-                            interaction.Audit_Reason__c += ' Reason: Error during Lead insert - ' + error.getMessage() + '.';
-                            System.debug('Error during Lead insert - ' + error.getMessage() + '.');
                         }
+                    } else { // Catch-all for all other errors
+                        interaction.Audit_Reason__c += ' Reason: Error during Lead insert - ' + error.getMessage() + '.';
+                        System.debug('Error during Lead insert - ' + error.getMessage() + '.');
                     }
                 }
             }
+
+            leadIndex++;
         }
 
         return leadsToConvert;

--- a/src/classes/INT_InteractionProcessor.cls
+++ b/src/classes/INT_InteractionProcessor.cls
@@ -11,7 +11,8 @@ public class INT_InteractionProcessor {
     private Map<Id, Lead> interactionIdToLead = new Map<Id, Lead>();
     private Map<Id, Interaction__c> interactionMap = new Map<Id, Interaction__c>();
     private Map<Id, Interaction__c> leadIdToInteractionMap = new Map<Id, Interaction__c>();
-    private Set<Id> leadIds = new Set<Id>();
+    private Set<Id> contactIds = new Set<Id>();
+    private Set<Id> existingLeadIds = new Set<Id>();
 
     private INT_InteractionMappingService intMappingService {
         get {
@@ -25,10 +26,10 @@ public class INT_InteractionProcessor {
         set;
     }
 
-    private Map<Id, Id> campaignIdMap {
+    private Map<String, Id> campaignIdMap {
         get {
             if (campaignIdMap == null) {
-                campaignIdMap = new Map<Id, Id>();
+                campaignIdMap = new Map<String, Id>();
                 Set<String> referenceIds = new Set<String>();
 
                 for (SObject interaction : Trigger.new) {
@@ -63,14 +64,14 @@ public class INT_InteractionProcessor {
 
                 // Loop through current Campaign Members and build campaignMemberMap
                 for (CampaignMember cm : [
-                    SELECT Status, ContactId, LeadId, CampaignId, Campaign.Campaign_Key__c
+                    SELECT Status, CampaignId, Campaign.Campaign_Key__c, Lead_Contact_ID__c
                     FROM CampaignMember
-                    WHERE LeadId IN :leadIds
+                    WHERE ContactId IN :contactIds
                 ]) {
                     if (!String.isEmpty(cm.Campaign.Campaign_Key__c)) {
-                        campaignMemberMap.put(String.valueOf(cm.LeadId + '.' + cm.Campaign.Campaign_Key__c), cm);
+                        campaignMemberMap.put(String.valueOf(cm.Lead_Contact_ID__c + '.' + cm.Campaign.Campaign_Key__c), cm);
                     } else {
-                        campaignMemberMap.put(String.valueOf(cm.LeadId + '.' + cm.CampaignId), cm);
+                        campaignMemberMap.put(String.valueOf(cm.Lead_Contact_ID__c + '.' + cm.CampaignId), cm);
                     }
                 }
             }
@@ -89,6 +90,33 @@ public class INT_InteractionProcessor {
             }
 
             return convertStatus;
+        }
+
+        set;
+    }
+
+    // Populate a Map of Existing Leads to map fields to new Interactions.
+    private Map<Id, Lead> existingLeadMap {
+        get {
+            if (existingLeadMap == null
+                && !existingLeadIds.isEmpty()
+                && intMappingService.intMappingMap != null
+                && intMappingService.intMappingMap.containsKey('Interaction__c')
+            ) {
+                String soqlString = 'SELECT Id';
+
+                for (Interaction_Mapping__c mapping : intMappingService.intMappingMap.get('Interaction__c')) {
+                    soqlString += ', ' + mapping.Source_Field_API_Name__c;
+                }
+
+                soqlString = soqlString.removeEnd(',').trim();
+                soqlString += ' FROM Lead WHERE Id IN :existingLeadIds';
+                existingLeadMap = new Map<Id, Lead>((List<Lead>) Database.query(soqlString));
+            } else if (existingLeadMap == null) {
+                existingLeadMap = new Map<Id, Lead>();
+            }
+
+            return existingLeadMap;
         }
 
         set;
@@ -122,7 +150,7 @@ public class INT_InteractionProcessor {
         }
 
         // Create CampaignMembers to upsert from the Leads inserted if they have the proper Campaign Keys
-        List<CampaignMember> campaignMembersToUpsert = createCampaignMembersFromLeads();
+        List<CampaignMember> campaignMembersToUpsert = createCampaignMembersFromLeads(true);
 
         // Upsert Campaign Members from Leads
         if (campaignMembersToUpsert.size() > 0) {
@@ -156,20 +184,20 @@ public class INT_InteractionProcessor {
         // Create Leads from new Interactions records.
         List<Database.LeadConvert> newLeads = insertLeadsFromInteractions(interactionsToProcess);
 
-        // Create CampaignMembers to upsert from the Leads inserted if they have the proper Campaign Keys
-        List<CampaignMember> campaignMembersToUpsert = createCampaignMembersFromLeads();
-
-        // Upsert Campaign Members from Leads
-        if (campaignMembersToUpsert.size() > 0) {
-            logPossibleErrors(Database.upsert(campaignMembersToUpsert, CampaignMember.Campaign_Member_Key__c, false));
-        }
-
         // Attempt initial conversion of leads.
         List<Database.LeadConvert> possibleLeadsToReconvert = convertLeads(newLeads);
 
         // Reconvert Leads with matched Contacts if duplicate errors.
         if (possibleLeadsToReconvert.size() > 0) {
             convertLeads(possibleLeadsToReconvert);
+        }
+
+        // Create CampaignMembers to upsert from the Leads inserted if they have the proper Campaign Keys
+        List<CampaignMember> campaignMembersToUpsert = createCampaignMembersFromLeads(false);
+
+        // Upsert Campaign Members from Leads
+        if (campaignMembersToUpsert.size() > 0) {
+            logPossibleErrors(Database.upsert(campaignMembersToUpsert, CampaignMember.Campaign_Member_Key__c, false));
         }
 
         // Upsert associated Opportunities using Opportunity_Key__c as the lookup Id.
@@ -330,6 +358,9 @@ public class INT_InteractionProcessor {
                                 // Grab matched record to use instead of the new one.
                                 interaction.Lead__c = match.getRecord().Id;
 
+                                // Add existing Lead Ids to List to query for data to copy to the Interaction later.
+                                existingLeadIds.add(match.getRecord().Id);
+
                                 if (interaction.Lead_Only__c == true) {
                                     leadIdToInteractionMap.put(interaction.Lead__c,interaction);
                                 } else {
@@ -387,6 +418,12 @@ public class INT_InteractionProcessor {
             if (lcr.isSuccess()) {
                 // Add Contact Id to set to be updated from its Interaction record.
                 interaction.Contact__c = lcr.getContactId();
+                contactIds.add(lcr.getContactId());
+
+                // If we had an existing Lead in SF, copy the values to the Interaction based upon the custom mdt.
+                if (existingLeadMap.containsKey(lcr.getLeadId())) {
+                    intMappingService.applyDataToInteraction(existingLeadMap.get(lcr.getLeadId()), interaction);
+                }
 
                 // Create new Opportunity for upsert if Opportunity Key is populated.
                 if (!String.isEmpty(interaction.Opportunity_Key__c)) {
@@ -446,13 +483,8 @@ public class INT_InteractionProcessor {
      * @return newAffil, the Affiliation__c record for upsert.
      */
     private hed__Affiliation__c createUpsertAffilFromInteraction(Interaction__c interaction) {
-        hed__Affiliation__c newAffil = new hed__Affiliation__c(
-            hed__Status__c = 'Current',
-            hed__Role__c = interaction.Affiliation_Role__c,
-            hed__Primary__c = interaction.Primary_Affiliation__c,
-            hed__Contact__c = interaction.Contact__c,
-            hed__Account__c = interaction.Affiliated_Account__c
-        );
+        hed__Affiliation__c newAffil = new hed__Affiliation__c();
+        
         intMappingService.applyDataToSObject(interaction, newAffil);
         newAffil.Upsert_Key__c = interaction.Contact__c + interaction.Affiliation_Key__c;
 
@@ -463,15 +495,14 @@ public class INT_InteractionProcessor {
      * @description Creates a List of CampaignMember records to upsert from the Leads that have been inserted.
      * @return campaignMembersToUpsert, the List of CampaignMember records to upsert.
      */
-    private List<CampaignMember> createCampaignMembersFromLeads() {
+    private List<CampaignMember> createCampaignMembersFromLeads(Boolean leadOnly) {
         List<CampaignMember> campaignMembersToUpsert = new List<CampaignMember>();
 
         for (String leadId : leadIdToInteractionMap.keySet()) {
             if (!String.isEmpty(leadIdToInteractionMap.get(leadId).Campaign_Member_Status__c)
                 && !String.isEmpty(leadIdToInteractionMap.get(leadId).Campaign_Key__c)
-                && !String.isEmpty(leadIdToInteractionMap.get(leadId).Lead__c)
             ) {
-                campaignMembersToUpsert.add(createUpsertCMFromInteraction(leadIdToInteractionMap.get(leadId), false));
+                campaignMembersToUpsert.add(createUpsertCMFromInteraction(leadIdToInteractionMap.get(leadId), false, leadOnly));
             }
 
             // Create a CampaignMember to Upsert for the Additional_Campaign_Key__c if it is populated.
@@ -479,7 +510,7 @@ public class INT_InteractionProcessor {
                 && !String.isEmpty(leadIdToInteractionMap.get(leadId).Additional_Campaign_Member_Status__c)
                 && !String.isEmpty(leadIdToInteractionMap.get(leadId).Lead__c)
             ) {
-                campaignMembersToUpsert.add(createUpsertCMFromInteraction(leadIdToInteractionMap.get(leadId), true));
+                campaignMembersToUpsert.add(createUpsertCMFromInteraction(leadIdToInteractionMap.get(leadId), true, leadOnly));
             }
         }
 
@@ -492,21 +523,27 @@ public class INT_InteractionProcessor {
      * @param additionalCampaign, a bool telling the method to use Campaign or Additional Campaign fields on the Interaction__c.
      * @return memberToUpsert, the CampaignMember to upsert.
      */
-    private CampaignMember createUpsertCMFromInteraction(Interaction__c interaction, Boolean additionalCampaign) {
+    private CampaignMember createUpsertCMFromInteraction(Interaction__c interaction, Boolean additionalCampaign, Boolean leadOnly) {
         CampaignMember memberToUpsert;
+        String leadOrContactId = (leadOnly) ? interaction.Lead__c : interaction.Contact__c;
         String campaignKey = (!additionalCampaign) ? interaction.Campaign_Key__c : interaction.Additional_Campaign_Key__c;
         String campaignMemberStatus = (!additionalCampaign) ? interaction.Campaign_Member_Status__c : interaction.Additional_Campaign_Member_Status__c;
-        String campaignMemberKey = String.valueOf(interaction.Lead__c + '.' + campaignKey);
+        String campaignMemberKey = String.valueOf(leadOrContactId + '.' + campaignKey);
 
         if (campaignMemberMap.containskey(campaignMemberKey)) {
             memberToUpsert = campaignMemberMap.get(campaignMemberKey);
-            memberToUpsert.Campaign_Member_Key__c = interaction.Lead__c + '.' + campaignIdMap.get(campaignKey);
+            memberToUpsert.Campaign_Member_Key__c = leadOrContactId + '.' + campaignIdMap.get(campaignKey);
         } else {
             memberToUpsert = new CampaignMember(
-                LeadId = interaction.Lead__c,
                 CampaignId = campaignIdMap.get(campaignKey),
-                Campaign_Member_Key__c = interaction.Lead__c + '.' + campaignIdMap.get(campaignKey)
+                Campaign_Member_Key__c = leadOrContactId + '.' + campaignIdMap.get(campaignKey)
             );
+
+            if (leadOnly) {
+                memberToUpsert.LeadId = interaction.Lead__c;
+            } else {
+                memberToUpsert.ContactId = interaction.Contact__c;
+            }
         }
 
         memberToUpsert.Status = campaignMemberStatus;

--- a/src/classes/INT_InteractionProcessor_TEST.cls
+++ b/src/classes/INT_InteractionProcessor_TEST.cls
@@ -205,7 +205,7 @@ private class INT_InteractionProcessor_TEST {
             Active__c = true
         );
 
-        if (planRTInfo != null && planRTInfo.get('Academic Plan').getRecordTypeId() != null) {
+        if (planRTInfo != null && planRTInfo.containsKey('Academic Plan')) {
             acadPlan.put('RecordTypeId', planRTInfo.get('Academic Plan').getRecordTypeId());
         }
 

--- a/src/classes/INT_InteractionProcessor_TEST.cls
+++ b/src/classes/INT_InteractionProcessor_TEST.cls
@@ -3,15 +3,17 @@
 * Author: Sierra-Cedar
 * Description: Unit Tests for INT_InteractionProcessor.cls
 ******************************************/
-@IsTest
+@isTest
 private class INT_InteractionProcessor_TEST {
-    @testSetup static void setUpTest() {
+    @testSetup
+    static void setUpTest() {
         // Create and insert Interaction Mapping Test Data
         List<Interaction_Mapping__c> testMappings = INT_TestDataFactory.createTestMappings();
         insert testMappings;
     }
 
-    static testMethod void testInsertDupeLeadsOnlyInImport() {
+    @isTest
+    static void testInsertDupeLeadsOnlyInImport() {
         // Arrange
         List<Interaction__c> interactionsToInsert = new List<Interaction__c>();
 
@@ -61,7 +63,8 @@ private class INT_InteractionProcessor_TEST {
                 'Duplicate pre-processing should have prevented the processing of duplicate records.');
     }
 
-    static testMethod void testBulkInsertLeadsOnly() {
+    @isTest
+    static void testBulkInsertLeadsOnly() {
         // Arrange
         List<Interaction__c> interactionsToInsert = INT_TestDataFactory.createBulkTestInteractions();
 
@@ -75,14 +78,14 @@ private class INT_InteractionProcessor_TEST {
         Test.stopTest();
 
         // Assert
-        List<Lead> leads = [SELECT FirstName, LastName FROM Lead];
         List<Contact> contacts = [SELECT Name, AccountId FROM Contact];
         System.assert(contacts.size() == 0);
         List<Account> accounts = [SELECT Name FROM Account];
         System.assert(accounts.size() == 0);
     }
 
-    static testMethod void testBulkInteractionInsert() {
+    @isTest
+    static void testBulkInteractionInsert() {
         // Arrange
         List<Interaction__c> interactionsToInsert = INT_TestDataFactory.createBulkTestInteractions();
 
@@ -130,7 +133,8 @@ private class INT_InteractionProcessor_TEST {
         }
     }
 
-    static testMethod void testPreProcessing() {
+    @isTest
+    static void testPreProcessing() {
         // Arrange
         List<Interaction__c> interactionsToInsert = new List<Interaction__c>();
 
@@ -175,7 +179,8 @@ private class INT_InteractionProcessor_TEST {
         System.assert(interactions[1].Interaction_Status__c == 'Imported');
     }
 
-    static testMethod void testOpportunityCreation() {
+    @isTest
+    static void testOpportunityCreation() {
         // Arrange
         Map<String, Schema.RecordTypeInfo> accRTInfo = Account.SObjectType.getDescribe().getRecordTypeInfosByName();
 
@@ -273,7 +278,8 @@ private class INT_InteractionProcessor_TEST {
         System.assertEquals(assertInteraction.Career__c, assertOppty.Career__c, 'Career__c should have been copied over to Opportunity.');
     }
 
-    static testMethod void testSkipMappingSources() {
+    @isTest
+    static void testSkipMappingSources() {
         // Arrange
         List<Interaction__c> interactionsToInsert = new List<Interaction__c>();
 
@@ -303,7 +309,8 @@ private class INT_InteractionProcessor_TEST {
         System.assert(accountMap.size() == 1, '1 Account Expected');
     }
 
-    static testMethod void testCampaignMemberCreation() {
+    @isTest
+    static void testCampaignMemberCreation() {
         // Arrange
         List<Campaign> testCampaigns = new List<Campaign>();
 
@@ -330,8 +337,6 @@ private class INT_InteractionProcessor_TEST {
         Test.stopTest();
 
         // Assert
-        List<Interaction__c> interactions = [SELECT First_Name__c, Last_Name__c, Email__c, Gender__c FROM Interaction__c];
-
         List<Lead> assertLeads = [SELECT FirstName, LastName FROM Lead];
         System.assert(assertLeads.size() == 0, 'Lead count expected to be at 0. Once converted, the Leads should be deleted');
 
@@ -356,5 +361,54 @@ private class INT_InteractionProcessor_TEST {
         System.assert(campaignMemberMap.containsKey(testAddlCampaign.Id), 'CampaignMember should exist for this Campaign.');
         System.assertEquals(testAddlCampaign.Id, campaignMemberMap.get(testAddlCampaign.Id).CampaignId, 'CampaignMember should have been created for test Campaign.');
         System.assertEquals(assertContacts[0].Id, campaignMemberMap.get(testAddlCampaign.Id).ContactId, 'Contact Id should match Contact created.');
+    }
+
+    @isTest
+    static void testCMCreationWithExistingLeadAndCM() {
+        // Arrange
+        Lead testLead = new Lead(
+            FirstName = 'Tony',
+            LastName = 'Stark',
+            Email = 'test@nomail.com',
+            Company = 'Stark, Tony'
+        );
+        insert testLead;
+
+        Campaign testCampaign = new Campaign(
+            Name = 'Test Campaign'
+        );
+        insert testCampaign;
+
+        Campaign testCampaign2 = new Campaign(
+            Name = 'Test Campaign 2'
+        );
+        insert testCampaign2;
+
+        CampaignMember testCM = new CampaignMember(
+            LeadId = testLead.Id,
+            CampaignId = testCampaign.Id,
+            Status = 'Added to Campaign'
+        );
+        insert testCM;
+
+        Interaction__c testInteraction = new Interaction__c(
+            First_Name__c = 'Tony',
+            Last_Name__c = 'Stark',
+            Email__c = 'test@nomail.com',
+            Campaign__c = testCampaign2.Id,
+            Campaign_Member_Status__c = 'Added to Campaign'
+        );
+
+        // Act
+        Test.startTest();
+        insert testInteraction;
+        Test.stopTest();
+
+        // Assert
+        Interaction__c assertInteraction = [SELECT Interaction_Status__c FROM Interaction__c WHERE Id = :testInteraction.Id];
+        System.assertEquals('Imported', assertInteraction.Interaction_Status__c, 'Interaction should have successfully imported.');
+
+        List<CampaignMember> assertCampaignMembers = [SELECT Contact.FirstName, Campaign.Name, Status, LeadId, ContactId FROM CampaignMember];
+        System.assertEquals(2, assertCampaignMembers.size(), '2 Campaign Members should have been created for the Lead/Interaction.');
     }
 }

--- a/src/classes/INT_InteractionProcessor_TEST.cls
+++ b/src/classes/INT_InteractionProcessor_TEST.cls
@@ -183,6 +183,7 @@ private class INT_InteractionProcessor_TEST {
     static void testOpportunityCreation() {
         // Arrange
         Map<String, Schema.RecordTypeInfo> accRTInfo = Account.SObjectType.getDescribe().getRecordTypeInfosByName();
+        Map<String, Schema.RecordTypeInfo> planRTInfo = Plan__c.SObjectType.getDescribe().getRecordTypeInfosByName();
 
         Account testCollege = new Account(
             Name = 'College of Arts & Sciences',
@@ -196,15 +197,6 @@ private class INT_InteractionProcessor_TEST {
         );
         insert testUniversity;
 
-        Plan__c recruitPlan = new Plan__c(
-            Name = 'BA - English',
-            Type__c = 'Recruitment',
-            Department__c = testCollege.Id,
-            Career__c = 'Undergraduate',
-            Active__c = true
-        );
-        insert recruitPlan;
-
         Plan__c acadPlan = new Plan__c(
             Name = 'Business Administration BA',
             Type__c = 'Academic',
@@ -212,6 +204,11 @@ private class INT_InteractionProcessor_TEST {
             Career__c = 'Undergraduate',
             Active__c = true
         );
+
+        if (planRTInfo != null && planRTInfo.get('Academic Plan').getRecordTypeId() != null) {
+            acadPlan.put('RecordTypeId', planRTInfo.get('Academic Plan').getRecordTypeId());
+        }
+
         insert acadPlan;
 
         hed__Term__c testFallTerm = new hed__Term__c(
@@ -266,7 +263,6 @@ private class INT_InteractionProcessor_TEST {
             FROM Contact
             WHERE Id = :assertInteraction.Contact__c
         ];
-        System.assertEquals(assertInteraction.Contact_Title__c, assertContact.Title, 'Title should have been copied over to Contact.');
         System.assertEquals(assertInteraction.Birthdate__c, assertContact.Birthdate, 'Birthdate should have been copied over to Contact.');
         System.assert(assertContact.hed__Affl_Accounts__r.size() == 1, 'Affiliation should have been created.');
         System.assertEquals(assertContact.hed__Affl_Accounts__r[0].hed__Account__c, testUniversity.Id, 'Affiliation Account should have been mapped to the testUniversity.');

--- a/src/classes/INT_TestDataFactory.cls
+++ b/src/classes/INT_TestDataFactory.cls
@@ -14,7 +14,7 @@ public class INT_TestDataFactory {
         /* CampaignMember Mappings */
         Interaction_Mapping__c campaignMemberStatusMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'CampaignMember',
-            Interaction_Source_Field_API_Name__c = 'Campaign_Member_Status__c',
+            Source_Field_API_Name__c = 'Campaign_Member_Status__c',
             Target_Field_API_Name__c = 'Status',
             Active__c = true
         );
@@ -23,7 +23,7 @@ public class INT_TestDataFactory {
         /* Contact Mappings */
         Interaction_Mapping__c contactBirthdateMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Birthdate__c',
+            Source_Field_API_Name__c = 'Birthdate__c',
             Target_Field_API_Name__c = 'Birthdate',
             Active__c = true
         );
@@ -31,23 +31,16 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactConstituentMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Constituent_ID__c',
+            Source_Field_API_Name__c = 'Constituent_ID__c',
             Target_Field_API_Name__c = 'Constituent_ID__c',
             Active__c = true
         );
         testMappingsToInsert.add(contactConstituentMapping);
 
-        Interaction_Mapping__c contactTitleMapping = new Interaction_Mapping__c(
-            Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Contact_Title__c',
-            Target_Field_API_Name__c = 'Title',
-            Active__c = true
-        );
-        testMappingsToInsert.add(contactTitleMapping);
 
         Interaction_Mapping__c contactEmailMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Email__c',
+            Source_Field_API_Name__c = 'Email__c',
             Target_Field_API_Name__c = 'Email',
             Active__c = true
         );
@@ -55,7 +48,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactFirstNameMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'First_Name__c',
+            Source_Field_API_Name__c = 'First_Name__c',
             Target_Field_API_Name__c = 'FirstName',
 			Skip_Mapping__c = 'Webform',
             Active__c = true
@@ -64,7 +57,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactGenderMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Gender__c',
+            Source_Field_API_Name__c = 'Gender__c',
             Target_Field_API_Name__c = 'hed__Gender__c',
             Skip_Mapping__c = 'Webform;Manual Entry',
             Active__c = true
@@ -73,7 +66,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactHomePhoneMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Home_Phone__c',
+            Source_Field_API_Name__c = 'Home_Phone__c',
             Target_Field_API_Name__c = 'HomePhone',
             Active__c = true
         );
@@ -81,7 +74,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactLastNameMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Last_Name__c',
+            Source_Field_API_Name__c = 'Last_Name__c',
             Target_Field_API_Name__c = 'LastName',
 			Skip_Mapping__c = 'Webform',
             Active__c = true
@@ -90,7 +83,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactLeadSourceMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Lead_Source__c',
+            Source_Field_API_Name__c = 'Lead_Source__c',
             Target_Field_API_Name__c = 'LeadSource',
             Active__c = true
         );
@@ -98,7 +91,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactMailingCityMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Mailing_City__c',
+            Source_Field_API_Name__c = 'Mailing_City__c',
             Target_Field_API_Name__c = 'MailingCity',
             Active__c = true
         );
@@ -106,7 +99,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactMailingCountryMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Mailing_Country__c',
+            Source_Field_API_Name__c = 'Mailing_Country__c',
             Target_Field_API_Name__c = 'MailingCountry',
             Active__c = true
         );
@@ -114,7 +107,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactMailingPostalCodeMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Mailing_Postal_Code__c',
+            Source_Field_API_Name__c = 'Mailing_Postal_Code__c',
             Target_Field_API_Name__c = 'MailingPostalCode',
             Active__c = true
         );
@@ -122,7 +115,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactMailingStateMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Mailing_State__c',
+            Source_Field_API_Name__c = 'Mailing_State__c',
             Target_Field_API_Name__c = 'MailingState',
             Active__c = true
         );
@@ -130,7 +123,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactMailingStreetMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Mailing_Street__c',
+            Source_Field_API_Name__c = 'Mailing_Street__c',
             Target_Field_API_Name__c = 'MailingStreet',
             Active__c = true
         );
@@ -138,7 +131,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactMobilePhoneMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Mobile_Phone__c',
+            Source_Field_API_Name__c = 'Mobile_Phone__c',
             Target_Field_API_Name__c = 'MobilePhone',
             Active__c = true
         );
@@ -146,7 +139,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c contactSalutationMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Contact',
-            Interaction_Source_Field_API_Name__c = 'Salutation__c',
+            Source_Field_API_Name__c = 'Salutation__c',
             Target_Field_API_Name__c = 'Salutation',
             Active__c = true
         );
@@ -155,7 +148,7 @@ public class INT_TestDataFactory {
         /* hed__Affiliation__c Mappings */
         Interaction_Mapping__c affiliationAccountMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'hed__Affiliation__c',
-            Interaction_Source_Field_API_Name__c = 'Affiliated_Account__c',
+            Source_Field_API_Name__c = 'Affiliated_Account__c',
             Target_Field_API_Name__c = 'hed__Account__c',
             Active__c = true
         );
@@ -163,7 +156,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c affiliationKeyMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'hed__Affiliation__c',
-            Interaction_Source_Field_API_Name__c = 'Affiliation_Key__c',
+            Source_Field_API_Name__c = 'Affiliation_Key__c',
             Target_Field_API_Name__c = 'Upsert_Key__c',
             Active__c = true
         );
@@ -171,7 +164,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c affiliationRoleMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'hed__Affiliation__c',
-            Interaction_Source_Field_API_Name__c = 'Affiliation_Role__c',
+            Source_Field_API_Name__c = 'Affiliation_Role__c',
             Target_Field_API_Name__c = 'hed__Role__c',
             Active__c = true
         );
@@ -179,7 +172,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c affiliationContactMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'hed__Affiliation__c',
-            Interaction_Source_Field_API_Name__c = 'Contact__c',
+            Source_Field_API_Name__c = 'Contact__c',
             Target_Field_API_Name__c = 'hed__Contact__c',
             Active__c = true
         );
@@ -187,32 +180,16 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c affiliationPrimaryMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'hed__Affiliation__c',
-            Interaction_Source_Field_API_Name__c = 'Primary_Affiliation__c',
+            Source_Field_API_Name__c = 'Primary_Affiliation__c',
             Target_Field_API_Name__c = 'hed__Primary__c',
             Active__c = true
         );
         testMappingsToInsert.add(affiliationPrimaryMapping);
 
         /* Lead Mappings */
-        Interaction_Mapping__c leadConstituentMapping = new Interaction_Mapping__c(
-            Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Constituent_ID__c',
-            Target_Field_API_Name__c = 'Constituent_ID__c',
-            Active__c = true
-        );
-        testMappingsToInsert.add(leadConstituentMapping);
-
-        Interaction_Mapping__c leadTitleMapping = new Interaction_Mapping__c(
-            Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Contact_Title__c',
-            Target_Field_API_Name__c = 'Title',
-            Active__c = true
-        );
-        testMappingsToInsert.add(leadTitleMapping);
-
         Interaction_Mapping__c leadEmailMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Email__c',
+            Source_Field_API_Name__c = 'Email__c',
             Target_Field_API_Name__c = 'Email',
             Active__c = true
         );
@@ -220,7 +197,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadFirstNameMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'First_Name__c',
+            Source_Field_API_Name__c = 'First_Name__c',
             Target_Field_API_Name__c = 'FirstName',
             Active__c = true
         );
@@ -228,7 +205,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadPhoneMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Home_Phone__c',
+            Source_Field_API_Name__c = 'Home_Phone__c',
             Target_Field_API_Name__c = 'Phone',
             Active__c = true
         );
@@ -236,7 +213,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadLastNameMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Last_Name__c',
+            Source_Field_API_Name__c = 'Last_Name__c',
             Target_Field_API_Name__c = 'LastName',
             Active__c = true
         );
@@ -244,7 +221,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadLeadSourceMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Lead_Source__c',
+            Source_Field_API_Name__c = 'Lead_Source__c',
             Target_Field_API_Name__c = 'LeadSource',
             Active__c = true
         );
@@ -252,7 +229,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadCityMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Mailing_City__c',
+            Source_Field_API_Name__c = 'Mailing_City__c',
             Target_Field_API_Name__c = 'City',
             Active__c = true
         );
@@ -260,7 +237,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadCountryMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Mailing_Country__c',
+            Source_Field_API_Name__c = 'Mailing_Country__c',
             Target_Field_API_Name__c = 'Country',
             Active__c = true
         );
@@ -268,7 +245,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadPostalCodeMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Mailing_Postal_Code__c',
+            Source_Field_API_Name__c = 'Mailing_Postal_Code__c',
             Target_Field_API_Name__c = 'PostalCode',
             Active__c = true
         );
@@ -276,7 +253,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadStateMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Mailing_State__c',
+            Source_Field_API_Name__c = 'Mailing_State__c',
             Target_Field_API_Name__c = 'State',
             Active__c = true
         );
@@ -284,7 +261,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadStreetMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Mailing_Street__c',
+            Source_Field_API_Name__c = 'Mailing_Street__c',
             Target_Field_API_Name__c = 'Street',
             Active__c = true
         );
@@ -292,7 +269,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadMobilePhoneMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Mobile_Phone__c',
+            Source_Field_API_Name__c = 'Mobile_Phone__c',
             Target_Field_API_Name__c = 'MobilePhone',
             Active__c = true
         );
@@ -300,7 +277,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c leadSalutationMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Lead',
-            Interaction_Source_Field_API_Name__c = 'Salutation__c',
+            Source_Field_API_Name__c = 'Salutation__c',
             Target_Field_API_Name__c = 'Salutation',
             Active__c = true
         );
@@ -309,7 +286,7 @@ public class INT_TestDataFactory {
         /* Opportunity Mappings */
         Interaction_Mapping__c opportunityAdmitTypeMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Admit_Type__c',
+            Source_Field_API_Name__c = 'Admit_Type__c',
             Target_Field_API_Name__c = 'Admit_Type__c',
             Active__c = true
         );
@@ -317,7 +294,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c opportunityContactMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Contact__c',
+            Source_Field_API_Name__c = 'Contact__c',
             Target_Field_API_Name__c = 'Contact__c',
             Active__c = true
         );
@@ -325,7 +302,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c opportunityLeadSourceMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Lead_Source__c',
+            Source_Field_API_Name__c = 'Lead_Source__c',
             Target_Field_API_Name__c = 'LeadSource',
             Active__c = true
         );
@@ -333,7 +310,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c opportunityNameMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Opportunity_Name__c',
+            Source_Field_API_Name__c = 'Opportunity_Name__c',
             Target_Field_API_Name__c = 'Name',
             Active__c = true
         );
@@ -341,7 +318,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c opportunityStageMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Opportunity_Stage__c',
+            Source_Field_API_Name__c = 'Opportunity_Stage__c',
             Target_Field_API_Name__c = 'StageName',
             Active__c = true
         );
@@ -349,7 +326,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c opportunityTermMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Term__c',
+            Source_Field_API_Name__c = 'Term__c',
             Target_Field_API_Name__c = 'Term__c',
             Active__c = true
         );
@@ -357,7 +334,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c opportunityAcadPlanMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Academic_Interest__c',
+            Source_Field_API_Name__c = 'Academic_Interest__c',
             Target_Field_API_Name__c = 'Academic_Interest__c',
             Active__c = true
         );
@@ -365,7 +342,7 @@ public class INT_TestDataFactory {
 
         Interaction_Mapping__c opportunityRecruitPlanMapping = new Interaction_Mapping__c(
             Target_Object_API_Name__c = 'Opportunity',
-            Interaction_Source_Field_API_Name__c = 'Recruitment_Interest__c',
+            Source_Field_API_Name__c = 'Recruitment_Interest__c',
             Target_Field_API_Name__c = 'Recruitment_Interest__c',
             Active__c = true
         );

--- a/src/layouts/Interaction_Mapping__c-Interaction Mapping Layout.layout
+++ b/src/layouts/Interaction_Mapping__c-Interaction Mapping Layout.layout
@@ -8,16 +8,19 @@
         <label>Information</label>
         <layoutColumns>
             <layoutItems>
+                <emptySpace>true</emptySpace>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Target_Object_API_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Target_Field_API_Name__c</field>
+                <field>Source_Object_API_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Interaction_Source_Field_API_Name__c</field>
+                <field>Insert_Null__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
@@ -27,14 +30,18 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Insert_Null__c</field>
+                <field>Target_Field_API_Name__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Source_Field_API_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Skip_Mapping__c</field>
             </layoutItems>
         </layoutColumns>
-        <style>TwoColumnsTopToBottom</style>
+        <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
         <customLabel>false</customLabel>
@@ -75,7 +82,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h0S000000IisG</masterLabel>
+        <masterLabel>00h1I000002zJuf</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/src/objects/CampaignMember.object
+++ b/src/objects/CampaignMember.object
@@ -3,13 +3,27 @@
     <fields>
         <fullName>Campaign_Member_Key__c</fullName>
         <caseSensitive>false</caseSensitive>
-        <description>Used by the Interactions process to update an existing Campaign Member. Set to Lead.ID + * + Campaign.ID. Also updated by a workflow rule.</description>
+        <description>The Contact ID.Campaign ID if it exists, used to to upsert Campaign Members in the Interaction process.</description>
         <externalId>true</externalId>
-        <inlineHelpText>Used by the Interactions process to update an existing Campaign Member.</inlineHelpText>
+        <inlineHelpText>The Contact ID.Campaign ID if it exists, used to to upsert Campaign Members in the Interaction process.</inlineHelpText>
         <label>Campaign Member Key</label>
         <length>255</length>
         <required>false</required>
         <type>Text</type>
         <unique>true</unique>
+    </fields>
+    <fields>
+        <fullName>Lead_Contact_ID__c</fullName>
+        <description>Displays the Lead or Contact ID related to the campaign member. Needed to make campaign member a sendable data extension in the Marketing Cloud.</description>
+        <externalId>false</externalId>
+        <formula>IF(
+            ISBLANK(ContactId),
+            CASESAFEID(LeadId),
+            CASESAFEID(ContactId)
+            )</formula>
+        <label>Lead/Contact ID</label>
+        <required>false</required>
+        <type>Text</type>
+        <unique>false</unique>
     </fields>
 </CustomObject>

--- a/src/objects/Interaction_Mapping__c.object
+++ b/src/objects/Interaction_Mapping__c.object
@@ -74,18 +74,6 @@
         <type>Checkbox</type>
     </fields>
     <fields>
-        <fullName>Interaction_Source_Field_API_Name__c</fullName>
-        <description>The source field on the Interaction object you would like to map to a Target Object field. The value in this field must be in API format and matches an existing field on Interaction.</description>
-        <externalId>false</externalId>
-        <inlineHelpText>The source field on the Interaction object you would like to map. Ensure this is in API format and matches the existing field on Interaction.</inlineHelpText>
-        <label>Interaction Source Field API Name</label>
-        <length>255</length>
-        <required>false</required>
-        <trackTrending>false</trackTrending>
-        <type>Text</type>
-        <unique>false</unique>
-    </fields>
-    <fields>
         <fullName>Skip_Mapping__c</fullName>
         <description>Select the Interaction Sources that should ignore this mapping configuration. The values in this picklist should match the values in Interaction&apos;s &quot;Interaction Sources&quot; field.</description>
         <externalId>false</externalId>
@@ -123,6 +111,44 @@
         <visibleLines>8</visibleLines>
     </fields>
     <fields>
+        <fullName>Source_Field_API_Name__c</fullName>
+        <description>The Source Object field you would like to map to a Target Object field. The value in this field must be in API format and matches an existing field on the Source Object.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The Source Object field you would like to map to a Target Object field. Ensure this is in API format and matches the existing field on the Source Object.</inlineHelpText>
+        <label>Source Field API Name</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Source_Object_API_Name__c</fullName>
+        <description>The API name of the Source Object to map to the Target Object. When adding new values, ensure that you use the API name of the object.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Select the Source Object to map to the Target Object.</inlineHelpText>
+        <label>Source Object API Name</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Picklist</type>
+        <valueSet>
+            <restricted>true</restricted>
+            <valueSetDefinition>
+                <sorted>false</sorted>
+                <value>
+                    <fullName>Lead</fullName>
+                    <default>false</default>
+                    <label>Lead</label>
+                </value>
+                <value>
+                    <fullName>Interaction__c</fullName>
+                    <default>true</default>
+                    <label>Interaction__c</label>
+                </value>
+            </valueSetDefinition>
+        </valueSet>
+    </fields>
+    <fields>
         <fullName>Target_Field_API_Name__c</fullName>
         <description>The field on the Target Object you would like to map an Interaction field value to. The value in this field must be in API format and match an existing field on the Target Object.</description>
         <externalId>false</externalId>
@@ -138,7 +164,7 @@
         <fullName>Target_Object_API_Name__c</fullName>
         <description>The API name of the Target Object to map Interaction data to. When adding new values, ensure that you use the API name of the object.</description>
         <externalId>false</externalId>
-        <inlineHelpText>Select the Target Object to map Interaction data to.</inlineHelpText>
+        <inlineHelpText>Select the Target Object to map Source Object data to.</inlineHelpText>
         <label>Target Object API Name</label>
         <required>false</required>
         <trackTrending>false</trackTrending>
@@ -171,6 +197,11 @@
                     <default>false</default>
                     <label>Opportunity</label>
                 </value>
+                <value>
+                    <fullName>Interaction__c</fullName>
+                    <default>false</default>
+                    <label>Interaction__c</label>
+                </value>
             </valueSetDefinition>
         </valueSet>
     </fields>
@@ -181,7 +212,7 @@
         <columns>Active__c</columns>
         <columns>Target_Object_API_Name__c</columns>
         <columns>Target_Field_API_Name__c</columns>
-        <columns>Interaction_Source_Field_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
         <columns>Insert_Null__c</columns>
         <columns>Skip_Mapping__c</columns>
         <filterScope>Everything</filterScope>
@@ -196,7 +227,8 @@
         <fullName>All</fullName>
         <columns>NAME</columns>
         <columns>Active__c</columns>
-        <columns>Interaction_Source_Field_API_Name__c</columns>
+        <columns>Source_Object_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
         <columns>Target_Object_API_Name__c</columns>
         <columns>Target_Field_API_Name__c</columns>
         <columns>Insert_Null__c</columns>
@@ -210,7 +242,7 @@
         <columns>Active__c</columns>
         <columns>Target_Object_API_Name__c</columns>
         <columns>Target_Field_API_Name__c</columns>
-        <columns>Interaction_Source_Field_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
         <columns>Insert_Null__c</columns>
         <columns>Skip_Mapping__c</columns>
         <filterScope>Everything</filterScope>
@@ -227,7 +259,7 @@
         <columns>Active__c</columns>
         <columns>Target_Object_API_Name__c</columns>
         <columns>Target_Field_API_Name__c</columns>
-        <columns>Interaction_Source_Field_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
         <columns>Insert_Null__c</columns>
         <columns>Skip_Mapping__c</columns>
         <filterScope>Everything</filterScope>
@@ -239,12 +271,12 @@
         <label>Contact</label>
     </listViews>
     <listViews>
-        <fullName>Lead</fullName>
+        <fullName>Interaction_to_Lead</fullName>
         <columns>NAME</columns>
         <columns>Active__c</columns>
         <columns>Target_Object_API_Name__c</columns>
         <columns>Target_Field_API_Name__c</columns>
-        <columns>Interaction_Source_Field_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
         <columns>Insert_Null__c</columns>
         <columns>Skip_Mapping__c</columns>
         <filterScope>Everything</filterScope>
@@ -253,7 +285,29 @@
             <operation>equals</operation>
             <value>Lead</value>
         </filters>
-        <label>Lead</label>
+        <label>Interaction to Lead</label>
+    </listViews>
+    <listViews>
+        <fullName>Lead_to_Interaction</fullName>
+        <columns>NAME</columns>
+        <columns>Active__c</columns>
+        <columns>Target_Object_API_Name__c</columns>
+        <columns>Target_Field_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
+        <columns>Insert_Null__c</columns>
+        <columns>Skip_Mapping__c</columns>
+        <filterScope>Everything</filterScope>
+        <filters>
+            <field>Target_Object_API_Name__c</field>
+            <operation>equals</operation>
+            <value>Interaction__c</value>
+        </filters>
+        <filters>
+            <field>Source_Object_API_Name__c</field>
+            <operation>equals</operation>
+            <value>Lead</value>
+        </filters>
+        <label>Lead to Interaction</label>
     </listViews>
     <listViews>
         <fullName>Opportunity</fullName>
@@ -261,7 +315,7 @@
         <columns>Active__c</columns>
         <columns>Target_Object_API_Name__c</columns>
         <columns>Target_Field_API_Name__c</columns>
-        <columns>Interaction_Source_Field_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
         <columns>Insert_Null__c</columns>
         <columns>Skip_Mapping__c</columns>
         <filterScope>Everything</filterScope>
@@ -271,6 +325,23 @@
             <value>Opportunity</value>
         </filters>
         <label>Opportunity</label>
+    </listViews>
+    <listViews>
+        <fullName>School</fullName>
+        <columns>NAME</columns>
+        <columns>Active__c</columns>
+        <columns>Target_Object_API_Name__c</columns>
+        <columns>Target_Field_API_Name__c</columns>
+        <columns>Source_Field_API_Name__c</columns>
+        <columns>Insert_Null__c</columns>
+        <columns>Skip_Mapping__c</columns>
+        <filterScope>Everything</filterScope>
+        <filters>
+            <field>Source_Field_API_Name__c</field>
+            <operation>contains</operation>
+            <value>School</value>
+        </filters>
+        <label>School</label>
     </listViews>
     <nameField>
         <displayFormat>INTMap-{000000}</displayFormat>
@@ -282,11 +353,11 @@
         <customTabListAdditionalFields>Active__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>Target_Object_API_Name__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>Target_Field_API_Name__c</customTabListAdditionalFields>
-        <customTabListAdditionalFields>Interaction_Source_Field_API_Name__c</customTabListAdditionalFields>
+        <customTabListAdditionalFields>Source_Field_API_Name__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>Insert_Null__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>Skip_Mapping__c</customTabListAdditionalFields>
-        <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
         <excludedStandardButtons>Accept</excludedStandardButtons>
+        <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
         <lookupDialogsAdditionalFields>Active__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>Target_Object_API_Name__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>Target_Field_API_Name__c</lookupDialogsAdditionalFields>
@@ -299,10 +370,26 @@
         <searchResultsAdditionalFields>Active__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>Target_Object_API_Name__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>Target_Field_API_Name__c</searchResultsAdditionalFields>
-        <searchResultsAdditionalFields>Interaction_Source_Field_API_Name__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>Source_Field_API_Name__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>Insert_Null__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>Skip_Mapping__c</searchResultsAdditionalFields>
     </searchLayouts>
     <sharingModel>ReadWrite</sharingModel>
+    <validationRules>
+        <fullName>Disallow_Interaction_as_Target_wo_Lead</fullName>
+        <active>true</active>
+        <description>Interaction can only be the Target Object if Lead is the Source Object.</description>
+        <errorConditionFormula>ISPICKVAL(Target_Object_API_Name__c, &quot;Interaction__c&quot;) &amp;&amp; NOT(ISPICKVAL(Source_Object_API_Name__c, &quot;Lead&quot;))</errorConditionFormula>
+        <errorDisplayField>Target_Object_API_Name__c</errorDisplayField>
+        <errorMessage>Invalid Objects: Interaction cannot be the Target Object unless Lead is the Source Object.</errorMessage>
+    </validationRules>
+    <validationRules>
+        <fullName>Disallow_Lead_as_Source_wo_Interaction</fullName>
+        <active>true</active>
+        <description>Lead can only be the Source Object if Interaction is the Target Object.</description>
+        <errorConditionFormula>ISPICKVAL(Source_Object_API_Name__c, &quot;Lead&quot;) &amp;&amp; NOT(ISPICKVAL(Target_Object_API_Name__c, &quot;Interaction__c&quot;))</errorConditionFormula>
+        <errorDisplayField>Source_Object_API_Name__c</errorDisplayField>
+        <errorMessage>Invalid Objects: Lead cannot be the Source Object unless Interaction is the Target Object.</errorMessage>
+    </validationRules>
     <visibility>Public</visibility>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -97,7 +97,6 @@
         <members>Interaction_Mapping__c.All</members>
         <members>Interaction_Mapping__c.CampaignMember</members>
         <members>Interaction_Mapping__c.Contact</members>
-        <members>Interaction_Mapping__c.Lead</members>
         <members>Interaction_Mapping__c.Opportunity</members>
         <members>Plan__c.Academic_Interests</members>
         <members>Plan__c.All</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -30,6 +30,7 @@
         <members>Campaign.Campaign_Key__c</members>
         <members>Campaign.Campaign_Reference_ID__c</members>
         <members>CampaignMember.Campaign_Member_Key__c</members>
+        <members>CampaignMember.Lead_Contact_ID__c</members>
         <members>Contact.Constituent_ID__c</members>
         <members>Contact.Primary_Academic_Program__c</members>
         <members>Contact.Primary_Educational_Institution__c</members>

--- a/src/profiles/Admin.profile
+++ b/src/profiles/Admin.profile
@@ -18,6 +18,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>CampaignMember.Lead_Contact_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Contact.Constituent_ID__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -43,7 +48,12 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>Interaction_Mapping__c.Interaction_Source_Field_API_Name__c</field>
+        <field>Interaction_Mapping__c.Source_Field_API_Name__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Interaction_Mapping__c.Source_Object_API_Name__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/src/triggers/INT_InteractionMapping.trigger
+++ b/src/triggers/INT_InteractionMapping.trigger
@@ -4,7 +4,6 @@
 * Description: Interaction_Mapping__c Trigger
 ******************************************/
 trigger INT_InteractionMapping on Interaction_Mapping__c (after insert, after update) {
-// Custom Validation for Interactin_Mapping__c
     Set<String> sObjectNames = new Set<String>{'Interaction__c'};
     Map<String, Set<String>> sObjectFieldStringsMap = new Map<String, Set<String>>();
 
@@ -44,10 +43,10 @@ trigger INT_InteractionMapping on Interaction_Mapping__c (after insert, after up
         }
 
         // Validate source field API name from the Interaction
-        if (sObjectFieldStringsMap.containsKey('Interaction__c')) {
-            if (!sObjectFieldStringsMap.get('Interaction__c').contains(mapping.Interaction_Source_Field_API_Name__c)) {
+        if (sObjectFieldStringsMap.containsKey(mapping.Source_Object_API_Name__c)) {
+            if (!sObjectFieldStringsMap.get(mapping.Source_Object_API_Name__c).contains(mapping.Source_Field_API_Name__c)) {
                 if (!String.isEmpty(errorString)) errorString += ' ';
-                errorString += 'Recruitment Import Field \'' + mapping.Interaction_Source_Field_API_Name__c + '\' does not exist ' +
+                errorString += 'Recruitment Import Field \'' + mapping.Source_Field_API_Name__c + '\' does not exist ' +
                     'on Interaction. Please choose a valid field to map from and ensure it is in API name format.';
             }
         }

--- a/src/workflows/CampaignMember.workflow
+++ b/src/workflows/CampaignMember.workflow
@@ -2,9 +2,9 @@
 <Workflow xmlns="http://soap.sforce.com/2006/04/metadata">
     <fieldUpdates>
         <fullName>Campaign_Member_Key_Update_to_Lead_Camp</fullName>
-        <description>Sets the Campaign Member Key field to LeadId.CampaignId</description>
+        <description>Sets the Lead/Contact Campaign field on Campaign Member to the 18-Digit Lead/Contact ID + the 18-Digit Campaign Id.</description>
         <field>Campaign_Member_Key__c</field>
-        <formula>LeadId&amp;&quot;.&quot;&amp;CampaignId</formula>
+        <formula>Lead_Contact_ID__c + &quot;.&quot; + CASESAFEID(CampaignId)</formula>
         <name>Campaign Member Key: Update to Lead.Camp</name>
         <notifyAssignee>false</notifyAssignee>
         <operation>Formula</operation>
@@ -17,8 +17,8 @@
             <type>FieldUpdate</type>
         </actions>
         <active>true</active>
-        <description>Runs on any update of Campaign Member associated to a Lead if the key is not Lead.Campaign</description>
-        <formula>NOT(ISBLANK(LeadId)) &amp;&amp; Campaign_Member_Key__c &lt;&gt; LeadId&amp;&quot;.&quot;&amp;CampaignId</formula>
+        <description>Update Campaign Member Lead/Contact Campaign if it does not equal 18-Digit Lead/Contact ID + &apos;.&apos; + 18-Digit Campaign Member ID.</description>
+        <formula>Lead_Contact_Campaign__c &lt;&gt; Lead_Contact_ID__c + &quot;.&quot; + CASESAFEID(CampaignId)</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
 </Workflow>

--- a/src/workflows/CampaignMember.workflow
+++ b/src/workflows/CampaignMember.workflow
@@ -2,7 +2,7 @@
 <Workflow xmlns="http://soap.sforce.com/2006/04/metadata">
     <fieldUpdates>
         <fullName>Campaign_Member_Key_Update_to_Lead_Camp</fullName>
-        <description>Sets the Lead/Contact Campaign field on Campaign Member to the 18-Digit Lead/Contact ID + the 18-Digit Campaign Id.</description>
+        <description>Sets the Campaign Member Key field on Campaign Member to the 18-Digit Lead/Contact ID + the 18-Digit Campaign Id.</description>
         <field>Campaign_Member_Key__c</field>
         <formula>Lead_Contact_ID__c + &quot;.&quot; + CASESAFEID(CampaignId)</formula>
         <name>Campaign Member Key: Update to Lead.Camp</name>
@@ -17,8 +17,8 @@
             <type>FieldUpdate</type>
         </actions>
         <active>true</active>
-        <description>Update Campaign Member Lead/Contact Campaign if it does not equal 18-Digit Lead/Contact ID + &apos;.&apos; + 18-Digit Campaign Member ID.</description>
-        <formula>Lead_Contact_Campaign__c &lt;&gt; Lead_Contact_ID__c + &quot;.&quot; + CASESAFEID(CampaignId)</formula>
+        <description>Update Campaign Member Key if it does not equal 18-Digit Lead/Contact ID + &apos;.&apos; + 18-Digit Campaign Member ID.</description>
+        <formula>Campaign_Member_Key__c &lt;&gt; Lead_Contact_ID__c + &quot;.&quot; + CASESAFEID(CampaignId)</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>
 </Workflow>


### PR DESCRIPTION
### Description

##### Various Bug Fixes for Campaign Member and Leads
- Change the way Campaign Members are created to prevent matching errors when a university loads Campaign Members outside of Interactions as well as with Interactions.
- Allow Lead fields to be written to Interaction before they are converted to Contacts. Without this enhancement, Lead fields cannot be mapped directly to Opportunities. They can still be mapped to Contacts using standard Lead field mappings.
- Write Lead back to the Interaction and leaves it when the process finds an existing Lead, so the ID can be used if needed.
- Change the way Affiliation fields are mapped to the Interaction. Use the Mapping Service instead of manually in the code.
- Fix issue where Leads would be out of sync with the contact list and apply data to the wrong Contact.
- Fix issue with Record Types for Plan__c where after adding the Record Type in the org the test wouldn't complete.